### PR TITLE
make OBDScanner able to communicate with CANAnalyzer

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -17,7 +17,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     if(!serialWrite_.isOpen())
     {
-        serialWrite_.openPort("COM7", 115200);
+        serialWrite_.openPort("COM7", 921600);
     }
 }
 
@@ -30,7 +30,7 @@ void MainWindow::onConnectButtonClicked()
 {
     if(!protocolHandler_.isOpen())
     {
-        protocolHandler_.openPort("COM8", 115200);
+        protocolHandler_.openPort("COM4", 921600);
     }
 }
 
@@ -68,14 +68,4 @@ void MainWindow::onSendCANMessageButtonClicked()
 {
     qDebug() << "msgCounter:" << static_cast<int>(message.msgCounter);
     qDebug() << "stdId:" << static_cast<int>(message.stdId);
-    qDebug() << "extId:" << static_cast<int>(message.extId);
-    qDebug() << "dlc:" << static_cast<int>(message.dlc);
-    qDebug() << "data[0]:" << static_cast<int>(message.data[0]);
-    qDebug() << "data[1]:" << static_cast<int>(message.data[1]);
-    qDebug() << "data[2]:" << static_cast<int>(message.data[2]);
-    qDebug() << "data[3]:" << static_cast<int>(message.data[3]);
-    qDebug() << "data[4]:" << static_cast<int>(message.data[4]);
-    qDebug() << "data[5]:" << static_cast<int>(message.data[5]);
-    qDebug() << "data[6]:" << static_cast<int>(message.data[6]);
-    qDebug() << "data[7]:" << static_cast<int>(message.data[7]);
 }

--- a/PacketParser.cpp
+++ b/PacketParser.cpp
@@ -7,13 +7,13 @@ void PacketParser::parse(std::vector<uint8_t>& packet)
     CANMessage message{};
     size_t offset{};
 
-    message.msgCounter = toLittleEndian16(packet.data() + offset);
+    std::memcpy(&message.msgCounter, packet.data() + offset, sizeof(message.msgCounter));
     offset += sizeof(message.msgCounter);
 
-    message.stdId = toLittleEndian32(packet.data() + offset);
+    std::memcpy(&message.stdId, packet.data() + offset, sizeof(message.stdId));
     offset += sizeof(message.stdId);
 
-    message.extId = toLittleEndian32(packet.data() + offset);
+    std::memcpy(&message.extId, packet.data() + offset, sizeof(message.extId));
     offset += sizeof(message.extId);
 
     message.ide = packet[offset++];
@@ -25,19 +25,8 @@ void PacketParser::parse(std::vector<uint8_t>& packet)
 
     message.fmi = packet[offset];
 
-    if(CANMessageCb != nullptr)
+    if(canMessageCb != nullptr)
     {
-        CANMessageCb(message);
+        canMessageCb(message);
     }
-}
-
-uint16_t PacketParser::toLittleEndian16(const uint8_t* data) {
-    return (static_cast<uint16_t>(data[0]) << 8) | data[1];
-}
-
-uint32_t PacketParser::toLittleEndian32(const uint8_t* data) {
-    return (static_cast<uint32_t>(data[0]) << 24) |
-           (static_cast<uint32_t>(data[1]) << 16) |
-           (static_cast<uint32_t>(data[2]) << 8) |
-           data[3];
 }

--- a/PacketParser.hpp
+++ b/PacketParser.hpp
@@ -23,12 +23,10 @@ public:
     ~PacketParser() = default;
     void setCANMessageCb(const std::function<void(CANMessage&)> callback)
     {
-        CANMessageCb = callback;
+        canMessageCb = callback;
     }
     void parse(std::vector<uint8_t>& packet);
 
 private:
-    std::function<void(CANMessage&)> CANMessageCb;
-    static uint16_t toLittleEndian16(const uint8_t* data);
-    static uint32_t toLittleEndian32(const uint8_t* data);
+    std::function<void(CANMessage&)> canMessageCb;
 };

--- a/ProtocolHandler.cpp
+++ b/ProtocolHandler.cpp
@@ -75,17 +75,9 @@ void ProtocolHandler::onReadyRead()
             switch (result.state)
             {
                 case DecodeResult::Completed:
-                    qDebug() << "Decoded stream: ";
-                    for (uint8_t byte : result.data)
-                    {
-                        qDebug() << static_cast<int>(byte) << " ";
-                    }
-
-                    qDebug() << "Parsing packet...";
                     packetParser_.parse(result.data);
                     break;
                 case DecodeResult::Ongoing:
-                    qDebug() << "Waiting for more data...";
                     return;
                 case DecodeResult::Error:
                     qDebug() << "Error: Malformed stream!";

--- a/StreamDecoder.cpp
+++ b/StreamDecoder.cpp
@@ -5,7 +5,6 @@ void StreamDecoder::reset()
     streamPtr_ = 0;
 }
 
-// StreamDecoder's decode implementation
 DecodeResult StreamDecoder::decode(const std::vector<uint8_t>& stream)
 {
     for(; streamPtr_ < stream.size() ; streamPtr_++)
@@ -66,4 +65,3 @@ bool StreamDecoder::cobsDecode(const std::vector<uint8_t>& encoded, std::vector<
 
     return true;
 }
-


### PR DESCRIPTION
For OBDScanner to be able to communicate with CANAnalyzer, this PR does the following.
- Changing baud rate from 115200 to 921600
- Removing the little-endian converter in OBDScanner
- Cleaning up the code