### PR TITLE
fix the size of the stream pointer in Decoder

### DIFF
--- a/StreamDecoder.hpp
+++ b/StreamDecoder.hpp
@@ -21,5 +21,5 @@ private:
     bool cobsDecode(const std::vector<uint8_t>& encoded, std::vector<uint8_t>& decoded);
 
     std::vector<uint8_t> buffer_;
-    uint8_t streamPtr_{};
+    uint32_t streamPtr_{};
 };


### PR DESCRIPTION
It increases the size of streamPtr in Decoder from 8bits to 32bits