### PR TITLE
ci: untrack build and deploy folders and their contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ Thumbs.db
 *.rc
 /.qmake.cache
 /.qmake.stash
+build/
+deploy/
 
 # qtcreator generated files
 *.pro.user*


### PR DESCRIPTION
It makes GIT to ignore any change in the below folders
- build
- deploy